### PR TITLE
Keep instance signletons on process to share between different rebus modules

### DIFF
--- a/lib/rebus.js
+++ b/lib/rebus.js
@@ -9,7 +9,10 @@ var suffix = '.json';
 var nfs = 'yosefsaysthiscannotbepropertyname';
 
 // Rebus instances created for folders.
-var singletons = {};
+// Keep them global to have only one instance per process.
+process.rebusinstances = {};
+// Used cached on process rebus instances only if they bare the same version.
+var rebusversion = 4;
 
 // Rebus factory.
 // Creates an instance of rebus in specified folder. The instance can be used in completion callback.
@@ -40,13 +43,19 @@ module.exports = function (folder, options, callback) {
   // Look if singleton for the folder already created.
 
   if (options.singletons) {
-    var singleton = singletons[folder];
+    var singleton = process.rebusinstances[folder];
     if (singleton) {
-      // Call completion after return value is available.
-      process.nextTick(function () {
-        callback();
-      });
-      return singleton;
+      // If not the same vesion, go and create new rebus instance.
+      if (singleton.version === rebusversion) {
+        // Call completion after return value is available.
+        process.nextTick(function () {
+          callback();
+        });
+        return singleton;
+      }
+      else {
+        console.warn('Incompatible rebus modules are running in this process. Found rebus instance for ' + folder + ' with incompatible version ' + singleton.version + ' versus current version ' + rebusversion);
+      }
     }
   }
 
@@ -69,10 +78,8 @@ module.exports = function (folder, options, callback) {
 
   // Create facade for rebus factory, which creates and initializes rebus instance.
   var instance = syncasyncFacade({ create: createInstance, initializeAsync: initializeAsync, initializeSync: initializeSync }, callback);
-  if (options.singletons) {
-    // Save this instance to return the same for the same folder.
-    singletons[folder] = instance;
-  }
+  // Version can be set immediately, not via facade.
+  instance.__defineGetter__("version", function () { return rebusversion; });
 
   /*
   // Factory methods.
@@ -99,6 +106,7 @@ module.exports = function (folder, options, callback) {
         }
         // Regardless errors, start watching the directory.
         _startWatchdog();
+        _updateSingleton();
         // Asynchronous initialization is completed.
         callback();
       });
@@ -109,6 +117,7 @@ module.exports = function (folder, options, callback) {
     var files = fs.readdirSync(folder);
     files.forEach(_loadFileSync);
     _startWatchdog();
+    _updateSingleton();
   }
 
   /*
@@ -184,6 +193,20 @@ module.exports = function (folder, options, callback) {
   /*
   // Private functions.
   */
+
+  // Store the instance of rebus per process to be
+  // reused if requried again.
+  function _updateSingleton() {
+    if (!options.singletons) {
+      return;
+    }
+    if (process.rebusinstances[folder]) {
+      // Somebody added instance already.
+      return;
+    }
+    // Save this instance to return the same for the same folder.
+    process.rebusinstances[folder] = instance;
+  }
 
   function _parseProp(prop) {
     if (!prop || typeof prop !== 'string' || prop.length < 1) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./main",
   "bin": {},
   "author": "anode <anode@microsoft.com>",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "license": "MIT",
   "contributors": [
     "Yosef Dinerstein <yosefd@microsoft.com>",


### PR DESCRIPTION
If modules are not compatible, warn and create own instance.
