### PR TITLE
Skip publishing and notification for identical object

### DIFF
--- a/lib/rebus.js
+++ b/lib/rebus.js
@@ -361,12 +361,14 @@ module.exports = function (folder, options, callback) {
         // The end of the path.
         if (obj) {
           // Skip object update if nothing changed.
-          if (!deepEqual(refobj[prop], obj)) {
-            // Pin the object here.
-            refobj[prop] = obj;
-            // Since object changed, append all notifications in the subtree.
-            _traverseSubtree(currentmeta, obj, fns);
+          if (deepEqual(currentobj, obj)) {
+            // No need to call all the notifications along the path.
+            return handler;
           }
+          // Pin the object here.
+          refobj[prop] = obj;
+          // Since object changed, append all notifications in the subtree.
+          _traverseSubtree(currentmeta, obj, fns);
         }
         if (notification) {
           // Pin notification at the end of the path.

--- a/lib/rebus.js
+++ b/lib/rebus.js
@@ -1,6 +1,7 @@
 ﻿var path = require('path');
 var fs = require('fs');
 var async = require('async');
+var deepEqual = require('deep-equal');
 var syncasyncFacade = require('ypatterns').syncasyncFacade;
 
 // Suffix for all published objects.
@@ -146,6 +147,10 @@ module.exports = function (folder, options, callback) {
     if (!prop || typeof prop !== 'string' || prop.length < 1) {
       throw new Error('invalid property path');
     }
+    if (_checkEqual(prop, obj)) {
+      // There is no change. Skip this publish.
+      return callback();
+    }
     // Write the object to the separate file.
     var shortname = prop + '.json';
     var fullname = path.join(folder, shortname);
@@ -203,6 +208,23 @@ module.exports = function (folder, options, callback) {
   /*
   // Private functions.
   */
+
+  // Check if the object inserted is equal to the exisitng object.
+  function _checkEqual(prop, obj) {
+    var props = prop.split('.');
+    var existing = shared;
+    props.forEach(function(p) {
+      if (existing) {
+        existing = existing[p];
+      }
+    });
+    if (existing) {
+      if (deepEqual(existing, obj)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   // Store the instance of rebus per process to be
   // reused if requried again.
@@ -338,10 +360,13 @@ module.exports = function (folder, options, callback) {
       if (i === (length - 1)) {
         // The end of the path.
         if (obj) {
-          // Pin the object here.
-          refobj[prop] = obj;
-          // Since object changed, append all notifications in the subtree.
-          _traverseSubtree(currentmeta, obj, fns);
+          // Skip object update if nothing changed.
+          if (!deepEqual(refobj[prop], obj)) {
+            // Pin the object here.
+            refobj[prop] = obj;
+            // Since object changed, append all notifications in the subtree.
+            _traverseSubtree(currentmeta, obj, fns);
+          }
         }
         if (notification) {
           // Pin notification at the end of the path.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./main",
   "bin": {},
   "author": "anode <anode@microsoft.com>",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "license": "MIT",
   "contributors": [
     "Yosef Dinerstein <yosefd@microsoft.com>",
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "async": "0.1.x",
+    "deep-equal": "0.0.x",
     "ypatterns": "0.2.x"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -219,11 +219,12 @@ module.exports = testCase({
       test.ok(rebus1, 'got the 1st rebus instance');
       var count1 = 0;
       var count2 = 0;
-      rebus1.subscribe('a', function (obj) {
+      var count3 = 0;
+      rebus1.subscribe('a.c', function (obj) {
         if (obj.b === 'b') {
           if (count1 === 0) {
             // Publish the identical object.
-            rebus1.publish('a', { b: 'b' });
+            rebus1.publish('a.c', { b: 'b' });
           }
           count1++;
         }
@@ -231,21 +232,32 @@ module.exports = testCase({
       var rebus2 = rebus(self.folder, function (err) {
         test.ok(!err, 'failed to start empty instance');
         test.ok(rebus2, 'got the 2nd rebus instance');
-        rebus2.subscribe('a', function (obj) {
+        rebus2.subscribe('a.c', function (obj) {
           if (obj.b === 'b') {
             count2++;
           }
         });
       });
+      var rebus3 = rebus(self.folder, function (err) {
+        test.ok(!err, 'failed to start empty instance');
+        test.ok(rebus3, 'got the 3rd rebus instance');
+        rebus3.subscribe('a', function (obj) {
+          if (obj.c && (obj.c.b === 'b')) {
+            count3++;
+          }
+        });
+      });
 
-      rebus1.publish('a', { b: 'b' });
+      rebus1.publish('a.c', { b: 'b' });
 
       setTimeout(function () {
         // Only one notification should be received after all.
         test.equal(count1, 1);
         test.equal(count2, 1);
+        test.equal(count3, 1);
         rebus1.close();
         rebus2.close();
+        rebus3.close();
         test.done();
       }, 200);
     });

--- a/test/test.js
+++ b/test/test.js
@@ -212,6 +212,45 @@ module.exports = testCase({
     });
   },
 
+  publishWithoutChange: function (test) {
+    var self = this;
+    var rebus1 = rebus(self.folder, function (err) {
+      test.ok(!err, 'failed to start empty instance');
+      test.ok(rebus1, 'got the 1st rebus instance');
+      var count1 = 0;
+      var count2 = 0;
+      rebus1.subscribe('a', function (obj) {
+        if (obj.b === 'b') {
+          if (count1 === 0) {
+            // Publish the identical object.
+            rebus1.publish('a', { b: 'b' });
+          }
+          count1++;
+        }
+      });
+      var rebus2 = rebus(self.folder, function (err) {
+        test.ok(!err, 'failed to start empty instance');
+        test.ok(rebus2, 'got the 2nd rebus instance');
+        rebus2.subscribe('a', function (obj) {
+          if (obj.b === 'b') {
+            count2++;
+          }
+        });
+      });
+
+      rebus1.publish('a', { b: 'b' });
+
+      setTimeout(function () {
+        // Only one notification should be received after all.
+        test.equal(count1, 1);
+        test.equal(count2, 1);
+        rebus1.close();
+        rebus2.close();
+        test.done();
+      }, 200);
+    });
+  },
+
   sync1: function (test) {
     var self = this;
     var rebus1 = rebus(self.folder, { singletons: false });


### PR DESCRIPTION
Only changes are propagated in both publishing and notification paths.

@saary @amitmach 
We need this change for notifications on bundle deployment configuration objects. Change of one bundle deployment configuration should not create notification for other bundle notifications. Without this fix, each update in farm's branch of cluster repository would create notification for each bundle deployment configuration in DSS deployment service, which we don't want.
