### PR TITLE
fix double notification

### DIFF
--- a/lib/rebus.js
+++ b/lib/rebus.js
@@ -81,6 +81,8 @@ module.exports = function (folder, options, callback) {
   var loader = { errors: {} };
   // Files hashes
   var hashes = [];
+  // Queues for serializing publishing for the same objects.
+  var publishQueues = {};
 
   // Create facade for rebus factory, which creates and initializes rebus instance.
   var instance = syncasyncFacade({ create: createInstance, initializeAsync: initializeAsync, initializeSync: initializeSync }, callback);
@@ -142,42 +144,53 @@ module.exports = function (folder, options, callback) {
   // obj - JSON object to publish.
   // callback(err) - completion.
   function publish(prop, obj, callback) {
-    if (callback && (typeof callback !== 'function')) {
+    callback = callback || function() {};
+    if (typeof callback !== 'function') {
       throw new Error('invalid callback');
     }
     if (!prop || typeof prop !== 'string' || prop.length < 1) {
       throw new Error('invalid property path');
     }
-    // Write the object to the separate file.
-    var shortname = prop + '.json';
-    var fullname = path.join(folder, shortname);
-    var data = JSON.stringify(obj);
-    if (!_checkNewHash(shortname, data)) {
-      // No need to publish is the data is the same.
-      if (callback) {
-        callback();
+
+    // Worker for publishing queue.
+    function _publish(obj, callback) {
+      // Write the object to the separate file.
+      var shortname = prop + '.json';
+      var fullname = path.join(folder, shortname);
+      var data = JSON.stringify(obj);
+      if (!_checkNewHash(shortname, data)) {
+        // No need to publish is the data is the same.
+        return callback();
       }
-      return;
-    }
-    // No need to subscribe to notifications if completion is not required.
-    if (callback) {
+      // The 1st notification if for subscription.
+      // The 2nd notification is for the change.
+      var count = 2;
       var handler = subscribe(prop, function(obj) {
-        var updatedData = JSON.stringify(obj);
-        if (updatedData === data) {
+        count--;
+        if (!count) {
           handler.close();
           // Completion when notification about change came back.
           return callback();
         }
       });
-    }
-    fs.writeFile(fullname, data, function (err) {
-      if (err) {
-        console.error('Failed to write file ' + fullname + ' err:', err);
-        if (callback) {
+      fs.writeFile(fullname, data, function (err) {
+        if (err) {
+          console.error('Failed to write file ' + fullname + ' err:', err);
           handler.close();
-          callback(err);
+          return callback(err);
         }
-      }
+      });
+    }
+
+    // If there is no queue for this object, create one.
+    if (!publishQueues[prop]) {
+      // Only one task should be executed by worker at any time.
+      publishQueues[prop] = async.queue(_publish, 1);
+    }
+    // Publishing of the same object should be queued and executed one after
+    // completion of another.
+    publishQueues[prop].push(obj, function(err) {
+      return callback(err);
     });
   }
 
@@ -333,11 +346,11 @@ module.exports = function (folder, options, callback) {
     _loadObject(filename, obj);
   }
 
-  function _loadObject(filename, obj, options) {
+  function _loadObject(filename, obj) {
     var props = filename.split('.');
     // Don't count suffix (.json).
     props.pop();
-    _traverse(props, obj, null, options);
+    _traverse(props, obj, null);
   }
 
   // Traverse the shared object according to property path.

--- a/lib/rebus.js
+++ b/lib/rebus.js
@@ -175,7 +175,7 @@ module.exports = function (folder, options, callback) {
       });
       fs.writeFile(fullname, data, function (err) {
         if (err) {
-          console.error('Failed to write file ' + fullname + ' err:', err);
+          console.error('Failed to write file %s err:', filename, err);
           handler.close();
           return callback(err);
         }

--- a/lib/rebus.js
+++ b/lib/rebus.js
@@ -159,7 +159,7 @@ module.exports = function (folder, options, callback) {
       var fullname = path.join(folder, shortname);
       var data = JSON.stringify(obj);
       if (!_checkNewHash(shortname, data)) {
-        // No need to publish is the data is the same.
+        // No need to publish if the data is the same.
         return callback();
       }
       // The 1st notification if for the subscription.

--- a/lib/rebus.js
+++ b/lib/rebus.js
@@ -142,8 +142,7 @@ module.exports = function (folder, options, callback) {
   // obj - JSON object to publish.
   // callback(err) - completion.
   function publish(prop, obj, callback) {
-    callback = callback || function () { };
-    if (typeof callback !== 'function') {
+    if (callback && (typeof callback !== 'function')) {
       throw new Error('invalid callback');
     }
     if (!prop || typeof prop !== 'string' || prop.length < 1) {
@@ -154,22 +153,30 @@ module.exports = function (folder, options, callback) {
     var fullname = path.join(folder, shortname);
     var data = JSON.stringify(obj);
     if (!_checkNewHash(shortname, data)) {
-      // No need to publish is the data is the same.      
-      return callback();
-    }
-    var handler = subscribe(prop, function(obj) {
-      var updatedData = JSON.stringify(obj);
-      if (updatedData === data) {
-        handler.close();
-        // Completion when notification about change came back.
-        return callback();
+      // No need to publish is the data is the same.
+      if (callback) {
+        callback();
       }
-    });
+      return;
+    }
+    // No need to subscribe to notifications if completion is not required.
+    if (callback) {
+      var handler = subscribe(prop, function(obj) {
+        var updatedData = JSON.stringify(obj);
+        if (updatedData === data) {
+          handler.close();
+          // Completion when notification about change came back.
+          return callback();
+        }
+      });
+    }
     fs.writeFile(fullname, data, function (err) {
       if (err) {
         console.error('Failed to write file ' + fullname + ' err:', err);
-        handler.close();
-        return callback(err);
+        if (callback) {
+          handler.close();
+          callback(err);
+        }
       }
     });
   }

--- a/lib/rebus.js
+++ b/lib/rebus.js
@@ -162,7 +162,7 @@ module.exports = function (folder, options, callback) {
         // No need to publish is the data is the same.
         return callback();
       }
-      // The 1st notification if for subscription.
+      // The 1st notification if for the subscription.
       // The 2nd notification is for the change.
       var count = 2;
       var handler = subscribe(prop, function(obj) {
@@ -189,9 +189,7 @@ module.exports = function (folder, options, callback) {
     }
     // Publishing of the same object should be queued and executed one after
     // completion of another.
-    publishQueues[prop].push(obj, function(err) {
-      return callback(err);
-    });
+    publishQueues[prop].push(obj, callback);
   }
 
   // Subscribe on changes.

--- a/lib/rebus.js
+++ b/lib/rebus.js
@@ -153,21 +153,24 @@ module.exports = function (folder, options, callback) {
     var shortname = prop + '.json';
     var fullname = path.join(folder, shortname);
     var data = JSON.stringify(obj);
-    if (!_checkNewHash(fullname, data)) {
+    if (!_checkNewHash(shortname, data)) {
       // No need to publish is the data is the same.      
       return callback();
     }
+    var handler = subscribe(prop, function(obj) {
+      var updatedData = JSON.stringify(obj);
+      if (updatedData === data) {
+        handler.close();
+        // Completion when notification about change came back.
+        return callback();
+      }
+    });
     fs.writeFile(fullname, data, function (err) {
       if (err) {
         console.error('Failed to write file ' + fullname + ' err:', err);
+        handler.close();
+        return callback(err);
       }
-      else {
-        // Update the publisher instance before completion.
-        // Notification are not called from this update, but from the trigger of the chagned
-        // file
-        _loadObject(shortname, obj, { notify: false });
-      }
-      callback(err);
     });
   }
 
@@ -272,7 +275,7 @@ module.exports = function (folder, options, callback) {
         return;
       }
       try {
-        _loadData(filename, data);
+        _loadData(filename, data.toString());
       }
       catch (e) {
         console.info('Object ' + filename + ' was not yet fully written, exception:', e);
@@ -309,7 +312,7 @@ module.exports = function (folder, options, callback) {
     var data = fs.readFileSync(path.join(folder, filename));
     // If file is written at the same time, this may raise exception. Since synchronous version is not
     // used in serious deployment scenarios, this is not important.
-    _loadData(filename, data);
+    _loadData(filename, data.toString());
   }
 
   function _loadData(filename, data) {
@@ -338,9 +341,7 @@ module.exports = function (folder, options, callback) {
   // notification - if defined, pin the notification at the end of the specified path.
   // Returns - if called with notification, returns the handler with information where the notification was pinned, so can be
   // unpinned later.
-  function _traverse(props, obj, notification, options) {
-
-    options = options || { notify: true };
+  function _traverse(props, obj, notification) {
     var length = props.length;
     var refobj = shared;
     var refmeta = meta;
@@ -396,7 +397,7 @@ module.exports = function (folder, options, callback) {
       refmeta = currentmeta;
     }
 
-    if (obj && options.notify) {
+    if (obj) {
       // Call all notifications.
       async.parallel(fns);
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "consumer"
   ],
   "engines": {
-    "node": "~0.6.x"
+    "node": "~0.10.x"
   },
   "dependencies": {
     "async": "0.1.x",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": "~0.10.x"
   },
   "dependencies": {
-    "async": "0.1.x",
+    "async": "0.2.x",
     "ypatterns": "0.2.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./main",
   "bin": {},
   "author": "yosefd <yosefd@microsoft.com>",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "license": "MIT",
   "contributors": [
     "Yosef Dinerstein <yosefd@microsoft.com>",

--- a/test/test.js
+++ b/test/test.js
@@ -358,7 +358,7 @@ module.exports = testCase({
         rebus1.close();
         rebus2.close();
         test.done();
-      }, 200);
+      }, 400);
     });
   },
 
@@ -433,7 +433,13 @@ module.exports = testCase({
       var rebus2;
       try {
         rebus2 = rebus(self.folder, { singletons: false });
-        test.deepEqual(rebus2.value, { a: { b: { c1: 'x', c2: 'y'}} });
+        var data1 = JSON.stringify(rebus2.value);
+        var data2 = JSON.stringify({ a: { b: { c1: 'x', c2: 'y'}}});
+        if (data1 !== data2) {
+          // This instance of rebus is not ready
+          rebuses.push(rebus2);
+          return;
+        }
       }
       catch (e) {
         // No problem. More notifications will come.
@@ -442,6 +448,7 @@ module.exports = testCase({
         rebuses.push(rebus2);
         return;
       }
+      test.deepEqual(rebus2.value, { a: { b: { c1: 'x', c2: 'y'}} });
       // If got here, rebus should be loaded successfully.
       notification1.close();
       rebus1.close();

--- a/test/test.js
+++ b/test/test.js
@@ -306,9 +306,7 @@ module.exports = testCase({
       test.ok(!err, 'failed to start empty instance');
       test.ok(rebus1, 'got the 1st rebus instance');
       var r1gotb = false;
-      var r1gotx = false;
       var r1gotz = false;
-      var r2gotb = false;
       var r2gotx = false;
       var r2gotz = false;
       // Number of notification may vary depending on file system behavior
@@ -327,9 +325,6 @@ module.exports = testCase({
           obj.b = 'x';
           rebus1.publish('a.c', obj);
         }
-        if (obj.b === 'x') {
-          r1gotx = true;
-        }
         if (obj.d === 'z') {
           r1gotz = true;
         }
@@ -340,9 +335,6 @@ module.exports = testCase({
         test.ok(rebus2, 'got the 2nd rebus instance');
         rebus2.subscribe('a.c', function (obj) {
           console.log('rebus2 got', obj);
-          if (obj.b === 'b') {
-            r2gotb = true;
-          }
           if (obj.b === 'x') {
             r2gotx = true;
             var obj = rebus2.value.a.c;
@@ -360,8 +352,8 @@ module.exports = testCase({
       setTimeout(function () {
         test.deepEqual(rebus1.value.a.c, { b: 'x', d: 'z' });
         test.deepEqual(rebus2.value.a.c, { b: 'x', d: 'z' });
-        test.ok(r1gotb && r2gotb);
-        test.ok(r1gotx && r2gotx);
+        test.ok(r1gotb);
+        test.ok(r2gotx);
         test.ok(r1gotz && r2gotz);
         rebus1.close();
         rebus2.close();

--- a/test/test.js
+++ b/test/test.js
@@ -296,7 +296,7 @@ module.exports = testCase({
         rebus2.close();
         rebus3.close();
         test.done();
-      }, 200);
+      }, 400);
     });
   },
 


### PR DESCRIPTION
notifications come from initial subscription and from change on the
object. the race was possible. now completion of publishing comes when
object is loaded and it is equal to the published.
assume that there is only one publisher for the same object, which was
always the rule of the game.

@amitmach @saary 
