### PR TITLE
Ignore files that start with a dot

### DIFF
--- a/lib/rebus.js
+++ b/lib/rebus.js
@@ -251,7 +251,7 @@ module.exports = function (folder, options, callback) {
     if (!watcher) {
       var watcherOptions = { persistent: !!options.persistent };
       watcher = fs.watch(folder, watcherOptions, function (event, filename) {
-        if (event === 'change') {
+        if (event === 'change' && filename.charAt(0) != '.') {
           // On every change load the changed file. This will trigger notifications for interested
           // subscribers.
           _loadFile(filename);
@@ -264,6 +264,12 @@ module.exports = function (folder, options, callback) {
   // Load object from a file. Update state and call notifications.
   function _loadFile(filename, callback) {
     callback = callback || function () { };
+
+    if (filename.charAt(0) == '.') {
+      callback();
+      return;
+    }
+
     var filepath = path.join(folder, filename);
     fs.readFile(filepath, function (err, data) {
       if (err) {

--- a/test/test.js
+++ b/test/test.js
@@ -454,5 +454,36 @@ module.exports = testCase({
         });
       }, 300);
     });
+  },
+
+  ignoreDotFilesDuringInitalLoad: function (test) {
+    var self = this;    
+    fs.writeFile(path.join(self.folder, '.c.json'), 'something', function (err) {
+      test.ok(!err, 'should write dot file');
+      var rebusT = rebus(self.folder, function (err) {
+        test.ok(!err, 'should get rebus instance');
+        test.deepEqual(rebusT.value, { });
+        rebusT.close();
+        test.done();
+      });
+    });
+  },
+
+  ignoreDotFilesOnUpdate: function (test) {
+    var self = this;
+    fs.writeFile(path.join(self.folder, '.c.json'), 'something', function (err) {
+      test.ok(!err, 'should write dot file');
+      var rebusT = rebus(self.folder, function (err) {
+        test.ok(!err, 'should get rebus instance');
+        fs.writeFile(path.join(self.folder, '.c.json'), '{}', function (err) {
+          test.ok(!err, 'should write full file');
+          setTimeout(function () {
+            test.deepEqual(rebusT.value, { });
+            rebusT.close();
+            test.done();
+          }, 300);
+        });
+      });
+    });
   }
 });

--- a/test/test.js
+++ b/test/test.js
@@ -3,12 +3,13 @@ var path = require('path');
 var rimraf = require('rimraf');
 var mkdirp = require('mkdirp');
 var fs = require('fs');
+var os = require('os');
 var rebus = require('../lib/rebus');
 
 module.exports = testCase({
 
   setUp: function (callback) {
-    this.folder = path.join(process.env.TMP || process.env.TMPDIR, 'rebus', Math.round(Math.random() * 100000).toString());
+    this.folder = path.join(process.env.TMP || process.env.TMPDIR || os.tmpdir(), 'rebus', Math.round(Math.random() * 100000).toString());
     console.log('Folder:' + this.folder);
     mkdirp(this.folder, callback);
   },


### PR DESCRIPTION
Directly editing files is a great way to test rebus applications, but some editors are creating temporary .dot-files and rebus throws an error. There's really no point watching them since they don't fit into the naming schema anyway.
